### PR TITLE
Add a timeout to `subscribe` APIs

### DIFF
--- a/examples/authenticated_api.rs
+++ b/examples/authenticated_api.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use bitmex_stream::Credentials;
 use bitmex_stream::Network;
 use futures::TryStreamExt;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,6 +17,7 @@ async fn main() -> Result<()> {
             api_key: "some_api_key".to_string(),
             secret: "some_secret".to_string(),
         },
+        Duration::from_secs(10),
     );
 
     while let Some(result) = stream.try_next().await? {

--- a/examples/xbt_usd_index_price.rs
+++ b/examples/xbt_usd_index_price.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bitmex_stream::Network;
 use futures::TryStreamExt;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -8,7 +9,11 @@ async fn main() -> Result<()> {
         .with_env_filter("info,bitmex_stream=trace")
         .init();
 
-    let mut stream = bitmex_stream::subscribe(["instrument:.BXBT".to_owned()], Network::Mainnet);
+    let mut stream = bitmex_stream::subscribe(
+        ["instrument:.BXBT".to_owned()],
+        Network::Mainnet,
+        Duration::from_secs(10),
+    );
 
     while let Some(result) = stream.try_next().await? {
         tracing::info!("{result}");

--- a/examples/xbt_usd_quote.rs
+++ b/examples/xbt_usd_quote.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bitmex_stream::Network;
 use futures::TryStreamExt;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -8,7 +9,11 @@ async fn main() -> Result<()> {
         .with_env_filter("info,bitmex_stream=trace")
         .init();
 
-    let mut stream = bitmex_stream::subscribe(["quoteBin1m:XBTUSD".to_owned()], Network::Mainnet);
+    let mut stream = bitmex_stream::subscribe(
+        ["quoteBin1m:XBTUSD".to_owned()],
+        Network::Mainnet,
+        Duration::from_secs(10),
+    );
 
     while let Some(result) = stream.try_next().await? {
         tracing::info!("{result}");

--- a/examples/xbt_usd_quote_testnet.rs
+++ b/examples/xbt_usd_quote_testnet.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bitmex_stream::Network;
 use futures::TryStreamExt;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -8,7 +9,11 @@ async fn main() -> Result<()> {
         .with_env_filter("info,bitmex_stream=trace")
         .init();
 
-    let mut stream = bitmex_stream::subscribe(["quoteBin1m:XBTUSD".to_owned()], Network::Testnet);
+    let mut stream = bitmex_stream::subscribe(
+        ["quoteBin1m:XBTUSD".to_owned()],
+        Network::Testnet,
+        Duration::from_secs(10),
+    );
 
     while let Some(result) = stream.try_next().await? {
         tracing::info!("{result}");


### PR DESCRIPTION
After the timeout, the handshake is retried if it did not complete.